### PR TITLE
eslint-best-practices: allow nested blocks

### DIFF
--- a/packages/eslint-config-emakinacee-base/rules/best-practices.js
+++ b/packages/eslint-config-emakinacee-base/rules/best-practices.js
@@ -123,8 +123,8 @@ module.exports = {
         // disallow use of labels for anything other then loops and switches
         'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
 
-        // disallow unnecessary nested blocks
-        'no-lone-blocks': 'error',
+        // allow nested blocks for grouping
+        'no-lone-blocks': 'off',
 
         // disallow creation of functions within loops
         'no-loop-func': 'error',


### PR DESCRIPTION
We may use code blocks as a form of organisation. It has less impact on readability than factoring out to a function and is less error prone than using just whitespace (separating groups by empty lines).